### PR TITLE
Refactor CI for comprehensive multi-platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,10 @@ jobs:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             build: make release-linux
-          - host: macos-latest
+          - host: macos-12
             target: x86_64-apple-darwin
             build: make release-mac-x86_64
           - host: macos-13-xlarge
-            target: aarch64-apple-darwin
-            build: make release-mac-aarch64
-          - host: macos-latest # This needs aarch64 OpenSSL, will wait github action support MacOS M1(https://github.com/github/roadmap/issues/528), then run this.
             target: aarch64-apple-darwin
             build: make release-mac-aarch64
     runs-on: ${{ matrix.settings.host }}
@@ -30,6 +27,7 @@ jobs:
         with:
           submodules: true
       - name: Install Rust
+        id: rust_toolchain # Added id for referencing output
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -44,7 +42,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            client/target/
+            target/
           key: ${{ matrix.settings.host }}-${{ matrix.settings.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ matrix.settings.host }}-cargo-${{ matrix.settings.target }}
       # - name: Setup tmate session
@@ -78,7 +76,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            client/target/
+            target/
           key: windows-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: windows-cargo
       - name: build
@@ -87,6 +85,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: tiny-mqtt-lib-win11-x86_64
+          name: tiny-mqtt-lib-${{ steps.rust_toolchain.outputs.target }}
           path: release/*
           if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -4,26 +4,26 @@
 
 release-mac-x86_64:
 	cargo build --release  --target=x86_64-apple-darwin
-	cp client/target/x86_64-apple-darwin/release/lib.dylib ./release/
+	cp target/x86_64-apple-darwin/release/lib.dylib ./release/
 
 release-mac-aarch64:
 	cargo build --release  --target=aarch64-apple-darwin
-	cp client/target/aarch64-apple-darwin/release/lib.dylib ./release/
+	cp target/aarch64-apple-darwin/release/lib.dylib ./release/
 
 release-linux-aarch64:
 	cargo build --release  --target=aarch64-unknown-linux-gnu
-	cp client/target/aarch64-unknown-linux-gnu/release/lib.o ./release/
+	cp target/aarch64-unknown-linux-gnu/release/liblib.so ./release/
 
 
 release-linux:
 	cargo build --release  --target=x86_64-unknown-linux-gnu
-	cp client/target/x86_64-unknown-linux-gnu/release/lib.o ./release/
+	cp target/x86_64-unknown-linux-gnu/release/liblib.so ./release/
 
 
 release-windows:
-	cargo build --release --target=stable-x86_64-pc-windows-msvc
-	cp target/stable-x86_64-pc-windows-msvc/release/lib.dll ./release/
-	cp target/stable-x86_64-pc-windows-msvc/release/lib.dll.lib ./release/
+	cargo build --release --target=x86_64-pc-windows-msvc
+	cp target/x86_64-pc-windows-msvc/release/lib.dll ./release/
+	cp target/x86_64-pc-windows-msvc/release/lib.dll.lib ./release/
 
 
 


### PR DESCRIPTION
This commit updates the GitHub Actions workflow and Makefile to build the library for the following target platforms:
- Linux (x86_64)
- macOS (x86_64 Intel)
- macOS (aarch64 ARM)
- Windows (x86_64)
